### PR TITLE
Fix dependency hash for #multicompile

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "javascript"
   ],
   "dependencies": {
-    "ember-script": "git://github.com/kristianmandrup/ember-script.git#mc",
+    "ember-script": "git://github.com/kristianmandrup/ember-script.git#multicompile",
     "broccoli-filter": "^0.1.0"
   }
 }


### PR DESCRIPTION
The branch appears to be called "multicompile" not "mc".  This should fix installation errors like:

  Failed resolving git HEAD (git://github.com/kristianmandrup/ember-script.git) fatal: ambiguous argument 'mc': unknown revision or path not in the working tree.
